### PR TITLE
Adding Solr Support to Synthesis and Content Search Tests

### DIFF
--- a/Build/PackageNuGet.ps1
+++ b/Build/PackageNuGet.ps1
@@ -41,3 +41,7 @@ $targetAssemblyVersion = $synthesisAssembly.ProductVersion
 & $nuGet pack "$scriptRoot\Synthesis.Mvc.nuget\Synthesis.Mvc.nuspec" -version $targetAssemblyVersion
 
 & $nuGet pack "$scriptRoot\..\Source\Synthesis.Mvc\Synthesis.Mvc.csproj" -Symbols -Prop Configuration=Release
+
+& $nuGet pack "$scriptRoot\Synthesis.Solr.nuget\Synthesis.Solr.nuspec" -version $targetAssemblyVersion
+
+& $nuGet pack "$scriptRoot\..\Source\Synthesis.Solr\Synthesis.Solr.csproj" -Symbols -Prop Configuration=Release

--- a/Build/Synthesis.Solr.nuget/Synthesis.Solr.nuspec
+++ b/Build/Synthesis.Solr.nuget/Synthesis.Solr.nuspec
@@ -1,24 +1,26 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Synthesis.Mvc</id>
+    <id>Synthesis.Solr</id>
     <version>$version$</version>
-    <authors>Ben Lipson,Kam Figy</authors>
+    <authors>Ben Lipson,Kam Figy,Jeff Darchuk</authors>
     <owners>Connective DX</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
     <projectUrl>https://github.com/blipson89/Synthesis</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
-      Automatic injection of Synthesis models for Sitecore MVC view renderings. This package contains the core library and configuration and is appropriate for the web project.
+      Adds Solr support to Synthesis. This package contains the core library and configuration and is appropriate for the web project.
+
+      NOTE: Synthesis 8.2.7 and above requires Sitecore 8.2 or higher
     </description>
     <copyright>Copyright 2017 Ben Lipson/Connective DX</copyright>
-    <tags>sitecore</tags>
+    <tags>sitecore,synthesis,solr</tags>
     <dependencies>
       <dependency id="Synthesis" version="$version$" />
-      <dependency id="Synthesis.Mvc.Core" version="$version$" />
+      <dependency id="Synthesis.Solr.Core" version="$version$" />
     </dependencies>
   </metadata>
   <files>
-       <file src="..\..\Source\Synthesis.Mvc\Synthesis.Mvc.config" target="content\App_Config\Include\Synthesis" />
+       <file src="..\..\Source\Synthesis.Solr\Standard Config Files\Synthesis.Solr.config" target="content\App_Config\Include\Synthesis" />
   </files>
 </package>

--- a/Build/Synthesis.nuget/Synthesis.nuspec
+++ b/Build/Synthesis.nuget/Synthesis.nuspec
@@ -3,20 +3,22 @@
   <metadata>
     <id>Synthesis</id>
     <version>$version$</version>
-    <authors>Kam Figy</authors>
-    <owners>ISITE Design</owners>
+    <authors>Ben Lipson,Kam Figy</authors>
+    <owners>Connective DX</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
-    <projectUrl>https://github.com/kamsar/Synthesis</projectUrl>
+    <projectUrl>https://github.com/blipson89/Synthesis</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
-		Synthesis is a universal object mapper with LINQ support for Sitecore 8.1 and 8.2. Use the same strongly typed objects to run queries against search indexes or the database, or transparently convert from indexed to database when necessary. Supports fully polymorphic Sitecore template inheritance via a generated interface hierarchy.
+		Synthesis is a universal object mapper with LINQ support for Sitecore 8.2. Use the same strongly typed objects to run queries against search indexes or the database, or transparently convert from indexed to database when necessary. Supports fully polymorphic Sitecore template inheritance via a generated interface hierarchy.
 		
 		This package contains both the Synthesis core library and the configuration for it, which is appropriate for web projects. Install Synthesis.Core if you only want the library.
+
+    NOTE: Synthesis 8.2.7 and above requires Sitecore 8.2 or higher
 	</description>
 	<summary>
-		Synthesis is a universal object mapper with LINQ support for Sitecore 8.1. This package contains both the Synthesis core library and the configuration for it, which is appropriate for web projects. Install Synthesis.Core if you only want the library.
+		Synthesis is a universal object mapper with LINQ support for Sitecore 8.2 and up. This package contains both the Synthesis core library and the configuration for it, which is appropriate for web projects. Install Synthesis.Core if you only want the library.
 	</summary>
-  <copyright>Copyright 2017 Kam Figy/Connective DX</copyright>
+  <copyright>Copyright 2017 Ben Lipson/Connective DX</copyright>
   <tags>sitecore</tags>
   <dependencies>
 		<dependency id="Synthesis.Core" version="$version$" />

--- a/Build/Synthesis.nuget/readme.txt
+++ b/Build/Synthesis.nuget/readme.txt
@@ -17,11 +17,11 @@ This file will be located at the ModelOutputPath in your config patch you create
 
 NOTE: your project including the model classes must reference Sitecore.Kernel and Sitecore.ContentSearch.Linq for the model to compile.
 
-Using modular architecture (e.g. Habitat) and need a model per module? See the example in the GitHub [README.md](https://github.com/kamsar/Synthesis) for directions to create a configuration registration.
+Using modular architecture (e.g. Habitat) and need a model per module? See the example in the GitHub [README.md](https://github.com/blipson89/Synthesis) for directions to create a configuration registration.
 
-Want deeper documentation? The Synthesis Wiki on GitHub has you covered: https://github.com/kamsar/Synthesis/wiki
+Want deeper documentation? The Synthesis Wiki on GitHub has you covered: https://github.com/blipson89/Synthesis/wiki
 
-Have questions? Tweet @kamsar or find me on Sitecore Community Slack.
+Have questions? Tweet @bllipson or find me on Sitecore Community Slack.
 
-Found a bug? Send me a pull request on GitHub if you're feeling awesome: https://github.com/kamsar/Synthesis
+Found a bug? Send me a pull request on GitHub if you're feeling awesome: https://github.com/blipson89/Synthesis
 (or an issue if you're feeling lazy)

--- a/Source/SharedAssemblyInfo.cs
+++ b/Source/SharedAssemblyInfo.cs
@@ -1,11 +1,11 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System;
 
 [assembly: AssemblyCompany("Connective DX")]
 [assembly: AssemblyProduct("Synthesis")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("8.2.6.0")]
-[assembly: AssemblyFileVersion("8.2.6.0")]
-[assembly: AssemblyInformationalVersion("8.2.6")]
+[assembly: AssemblyVersion("8.2.7.0")]
+[assembly: AssemblyFileVersion("8.2.7.0")]
+[assembly: AssemblyInformationalVersion("8.2.7-RC01")]
 [assembly: CLSCompliant(false)]

--- a/Source/Synthesis.Mvc/Synthesis.Mvc.nuspec
+++ b/Source/Synthesis.Mvc/Synthesis.Mvc.nuspec
@@ -3,15 +3,15 @@
   <metadata>
     <id>Synthesis.Mvc.Core</id>
     <version>$version$</version>
-    <authors>Kam Figy</authors>
-    <owners>ISITE Design</owners>
+    <authors>Ben Lipson,Kam Figy</authors>
+    <owners>Connective DX</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
-    <projectUrl>https://github.com/kamsar/Synthesis</projectUrl>
+    <projectUrl>https://github.com/blipson89/Synthesis</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
-		Automatic injection of Synthesis models for Sitecore MVC view renderings. This package contains the core library for class libraries. Use Synthesis.Mvc to include configuration.
-	</description>
-    <copyright>Copyright 2015 Kam Figy/Connective DX</copyright>
+		  Automatic injection of Synthesis models for Sitecore MVC view renderings. This package contains the core library for class libraries. Use Synthesis.Mvc to include configuration.
+	  </description>
+    <copyright>Copyright 2017 Ben Lipson/Connective DX</copyright>
     <tags>sitecore</tags>
     <dependencies>
     </dependencies>

--- a/Source/Synthesis.Solr/ContentSearch/Solr/ResolveSolrQueryable.cs
+++ b/Source/Synthesis.Solr/ContentSearch/Solr/ResolveSolrQueryable.cs
@@ -1,38 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Sitecore.ContentSearch;
 using Sitecore.ContentSearch.Diagnostics;
 using Sitecore.ContentSearch.Linq.Common;
 using Sitecore.ContentSearch.SolrProvider;
 using Sitecore.ContentSearch.Utilities;
 using Sitecore.Diagnostics;
+using Synthesis.ContentSearch;
 using Synthesis.Pipelines;
-using Synthesis.Solr.ContentSearch;
 
-namespace Synthesis.Solr.Pipelines.ContentSearch
+namespace Synthesis.Solr.ContentSearch.Solr
 {
-	public class ResolveSolrQueryable
+	public class ResolveSolrQueryable : IQueryableResolver
 	{
-		public void Process(SynthesisSearchContextArgs args)
+		public IQueryable<TResult> GetSynthesisQueryable<TResult>(SynthesisSearchContextArgs args) where TResult : IStandardTemplateItem
 		{
 			Assert.IsNotNull(args, "Args must not be null");
 			var solrContext = args.SearchContext as SolrSearchContext;
-			if (solrContext != null)
-			{
-				var overrideMapper = new SynthesisSolrDocumentTypeMapper();
-				overrideMapper.Initialize(args.SearchContext.Index);
-				var mapperExecutionContext = new OverrideExecutionContext<IIndexDocumentPropertyMapper<Dictionary<string, object>>>(overrideMapper);
-				var executionContexts = new List<IExecutionContext>();
-				if (args.ExecutionContext != null) executionContexts.AddRange(args.ExecutionContext);
-				executionContexts.Add(mapperExecutionContext);
-				var m = GetType().GetMethod("GetSolrQueryable", BindingFlags.NonPublic | BindingFlags.Instance).MakeGenericMethod(args.SynthesisQueryType);
-				args.SynthesisQueryable = (IQueryable)m.Invoke(this, new object[] { solrContext, executionContexts.ToArray() });
-			}
-			else
+			if (solrContext == null)
 				throw new NotImplementedException("A Solr index is not being used, if you're using Lucene make sure that you're not overridding the synthesisSearchContext pipeline with the Solr processor");
 
+			var overrideMapper = new SynthesisSolrDocumentTypeMapper();
+			overrideMapper.Initialize(args.SearchContext.Index);
+			var mapperExecutionContext = new OverrideExecutionContext<IIndexDocumentPropertyMapper<Dictionary<string, object>>>(overrideMapper);
+			var executionContexts = new List<IExecutionContext>();
+			if (args.ExecutionContext != null) executionContexts.AddRange(args.ExecutionContext);
+			executionContexts.Add(mapperExecutionContext);
+			return GetSolrQueryable<TResult>(solrContext, executionContexts.ToArray());
 		}
 		private IQueryable<TResult> GetSolrQueryable<TResult>(SolrSearchContext context, IExecutionContext[] executionContext)
 			where TResult : IStandardTemplateItem

--- a/Source/Synthesis.Solr/ContentSearch/SynthesisLinqToSolrIndex.cs
+++ b/Source/Synthesis.Solr/ContentSearch/SynthesisLinqToSolrIndex.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.ContentSearch.Linq.Solr;
+using Sitecore.ContentSearch.SolrProvider;
+using SolrNet;
+
+namespace Synthesis.Solr.ContentSearch
+{
+	public class SynthesisLinqToSolrIndex<T> : LinqToSolrIndex<T>
+	{
+		private readonly FieldNameTranslator _fieldNameTranslator;
+		public SynthesisLinqToSolrIndex(SolrSearchContext context) : this(context, null)
+		{
+		}
+		public SynthesisLinqToSolrIndex(SolrSearchContext context, params IExecutionContext[] executionContexts)
+			: base(context, executionContexts)
+		{
+			_fieldNameTranslator = new SynthesisSolrFieldNameTranslator(context, context.Index.FieldNameTranslator); ;
+		}
+		protected override FieldNameTranslator FieldNameTranslator
+		{
+			get { return _fieldNameTranslator; }
+		}
+		/*
+		 * THIS METHOD IS A TOTAL HACK
+		 * They exist to work around a bug in Sitecore (7.x-8.0 at least) where it uses private reflection
+		 * in such a way that it breaks all derived classes of LinqToSolrIndex when the solr query is mapped
+		 * in a particular way, such as when using a database name in your search query.
+		 * 
+		 * These basically act as proxies so the private reflection in Sitecore hits these methods,
+		 * which then reflect the call down to the base class' private method as is expected.
+		 * 
+		 * Source of hack: the Execute() method on the base class doing this:
+		 * MethodInfo methodInfo = this.GetType().GetMethod("ApplyScalarMethods", BindingFlags.Instance | BindingFlags.NonPublic).MakeGenericMethod(typeof (TResult), resultType);
+		 * 
+		 * The this.GetType() cause it to look for the private methods on any derived classes, where they do not exist.
+		 */
+		private TResult ApplyScalarMethods<TResult, TDocument>(SolrCompositeQuery compositeQuery, object processedResults, SolrQueryResults<Dictionary<string, object>> results)
+		{
+			var baseMethod = typeof(LinqToSolrIndex<T>).GetMethod("ApplyScalarMethods", BindingFlags.Instance | BindingFlags.NonPublic).MakeGenericMethod(typeof(TResult), typeof(TDocument));
+
+			return (TResult)baseMethod.Invoke(this, new[] { compositeQuery, processedResults, results });
+		}
+	}
+}

--- a/Source/Synthesis.Solr/ContentSearch/SynthesisLinqToSolrIndex.cs
+++ b/Source/Synthesis.Solr/ContentSearch/SynthesisLinqToSolrIndex.cs
@@ -9,19 +9,16 @@ namespace Synthesis.Solr.ContentSearch
 {
 	public class SynthesisLinqToSolrIndex<T> : LinqToSolrIndex<T>
 	{
-		private readonly FieldNameTranslator _fieldNameTranslator;
 		public SynthesisLinqToSolrIndex(SolrSearchContext context) : this(context, null)
 		{
 		}
 		public SynthesisLinqToSolrIndex(SolrSearchContext context, params IExecutionContext[] executionContexts)
 			: base(context, executionContexts)
 		{
-			_fieldNameTranslator = new SynthesisSolrFieldNameTranslator(context, context.Index.FieldNameTranslator); ;
+			FieldNameTranslator = new SynthesisSolrFieldNameTranslator(context, context.Index.FieldNameTranslator); ;
 		}
-		protected override FieldNameTranslator FieldNameTranslator
-		{
-			get { return _fieldNameTranslator; }
-		}
+		protected override FieldNameTranslator FieldNameTranslator { get; }
+
 		/*
 		 * THIS METHOD IS A TOTAL HACK
 		 * They exist to work around a bug in Sitecore (7.x-8.0 at least) where it uses private reflection
@@ -36,6 +33,7 @@ namespace Synthesis.Solr.ContentSearch
 		 * 
 		 * The this.GetType() cause it to look for the private methods on any derived classes, where they do not exist.
 		 */
+		// ReSharper disable once UnusedMember.Local
 		private TResult ApplyScalarMethods<TResult, TDocument>(SolrCompositeQuery compositeQuery, object processedResults, SolrQueryResults<Dictionary<string, object>> results)
 		{
 			var baseMethod = typeof(LinqToSolrIndex<T>).GetMethod("ApplyScalarMethods", BindingFlags.Instance | BindingFlags.NonPublic).MakeGenericMethod(typeof(TResult), typeof(TDocument));

--- a/Source/Synthesis.Solr/ContentSearch/SynthesisSolrDocumentTypeMapper.cs
+++ b/Source/Synthesis.Solr/ContentSearch/SynthesisSolrDocumentTypeMapper.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Sitecore.ContentSearch.SolrProvider.Mapping;
+using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.ContentSearch.Linq.Methods;
+using Sitecore.ContentSearch.Security;
+using Sitecore.Diagnostics;
+using Synthesis.ContentSearch;
+using System.Collections;
+using System.Text;
+
+namespace Synthesis.Solr.ContentSearch
+{
+	public class SynthesisSolrDocumentTypeMapper : SolrDocumentPropertyMapper
+	{
+		private readonly SynthesisDocumentTypeMapper _synthesisMapper = new SynthesisDocumentTypeMapper();
+		public override TElement MapToType<TElement>(Dictionary<string, object> document, SelectMethod selectMethod, IEnumerable<IFieldQueryTranslator> virtualFieldProcessors, IEnumerable<IExecutionContext> executionContexts, SearchSecurityOptions securityOptions)
+		{
+			ConvertDocumentToSythesisStandardTemplate(document);
+			var mappingResult = _synthesisMapper.MapToType<TElement>(() => ExtractFieldsFromDocument(document, virtualFieldProcessors), selectMethod);
+
+			// if the result type is not IStandardTemplateItem, use the default functionality
+			if (!mappingResult.MappedSuccessfully)
+				return base.MapToType<TElement>(document, selectMethod, virtualFieldProcessors, executionContexts, securityOptions);
+
+			return mappingResult.Document;
+		}
+		/// <summary>
+		/// there are some differences in how SOLR stores the standard fields, thus we need to convert a few of the solr fields
+		/// into something that synthesis will recognize
+		/// </summary>
+		/// <param name="document">the Solr results document</param>
+		private void ConvertDocumentToSythesisStandardTemplate(Dictionary<string, object> document)
+		{
+			string textSuffix = (Sitecore.Context.Site == null || Sitecore.Context.Language.Name == Sitecore.Context.Site.Language)? "_t" : "_t_"+Sitecore.Context.Language.Name.ToLower();
+			if (document.ContainsKey("__smallcreateddate_tdt"))
+				document["__smallcreateddate"] = document["__smallcreateddate_tdt"];
+			if (document.ContainsKey("__smallupdateddate_tdt"))
+				document["__smallupdateddate"] = document["__smallupdateddate_tdt"];
+			if (document.ContainsKey("__display_name" + textSuffix))
+				document["__display_name"] = document["__display_name" + textSuffix];
+			if (document.ContainsKey("__created_by_s"))
+				document["parsedcreatedby"] = document["__created_by_s"];
+			//updatedby is not available in the solr index
+		}
+
+		private Dictionary<string, string> ExtractFieldsFromDocument(IDictionary<string, object> document, IEnumerable<IFieldQueryTranslator> virtualFieldProcessors)
+		{
+			Assert.ArgumentNotNull(document, "document");
+			if (virtualFieldProcessors != null)
+				document = virtualFieldProcessors.Aggregate(document, (current, processor) => processor.TranslateFieldResult(current, index.FieldNameTranslator));
+
+			return document.ToDictionary(x => x.Key, x => ObjectToString(x.Value));
+		}
+		private static string ObjectToString(object value)
+		{
+			var arrayList = value as ArrayList;
+			if (arrayList == null) return value.ToString();
+			// sitecore uses arraylists, and they can't use linq extensions :(
+			StringBuilder sb = new StringBuilder();
+			foreach (object o in arrayList)
+				sb.Append(o).Append("|");
+			sb.Remove(sb.Length - 1,1);
+			return sb.ToString();
+		}
+
+	}
+}

--- a/Source/Synthesis.Solr/ContentSearch/SynthesisSolrFieldNameTranslator.cs
+++ b/Source/Synthesis.Solr/ContentSearch/SynthesisSolrFieldNameTranslator.cs
@@ -1,0 +1,44 @@
+﻿using System.Linq;
+using System.Reflection;
+using Sitecore;
+using Sitecore.ContentSearch;
+using SolrNet.Schema;
+using Synthesis.ContentSearch;
+
+namespace Synthesis.Solr.ContentSearch
+{
+	public class SynthesisSolrFieldNameTranslator : SynthesisFieldNameTranslator
+	{
+		private readonly SolrSchema _schema;
+		public SynthesisSolrFieldNameTranslator(IProviderSearchContext context, AbstractFieldNameTranslator translator)
+			: base(translator)
+		{
+			//sitecore hides the solr schema behind a private field, we need it to find dynamic fields.
+			var fieldInfo = context.Index.Schema.GetType().GetField("schema", BindingFlags.NonPublic | BindingFlags.Instance);
+			if (fieldInfo != null)
+				_schema = (SolrSchema)fieldInfo.GetValue(context.Index.Schema);
+		}
+
+		public override string GetIndexFieldName(string fieldName)
+		{
+			if (_schema != null && _schema.FindSolrFieldByName(fieldName) != null || _schema.SolrDynamicFields.Any(x => fieldName.EndsWith(x.Name.Substring(1))))
+				return fieldName;
+			//at this point we can't be sure what type the data is in the field, our best bet would be a text field.
+			return AppendSolrText(fieldName);
+		}
+		/// <summary>
+		/// If the context is a foreign language we should use the foreign language text solr fields
+		/// </summary>
+		/// <param name="fieldName">the initial field name</param>
+		/// <returns>field name with a dynamic field identifier on it</returns>
+		private string AppendSolrText(string fieldName)
+		{
+			if (Context.Site == null || Context.Language.Name == Context.Site.Language)
+				fieldName += "_t";
+			else
+				fieldName += "_t_" + Context.Language;
+			return fieldName;
+		}
+
+	}
+}

--- a/Source/Synthesis.Solr/Pipelines/ContentSearch/ResolveSolrQueryable.cs
+++ b/Source/Synthesis.Solr/Pipelines/ContentSearch/ResolveSolrQueryable.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Sitecore.ContentSearch;
+using Sitecore.ContentSearch.Diagnostics;
+using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.ContentSearch.SolrProvider;
+using Sitecore.ContentSearch.Utilities;
+using Sitecore.Diagnostics;
+using Synthesis.Pipelines;
+using Synthesis.Solr.ContentSearch;
+
+namespace Synthesis.Solr.Pipelines.ContentSearch
+{
+	public class ResolveSolrQueryable
+	{
+		public void Process(SynthesisSearchContextArgs args)
+		{
+			Assert.IsNotNull(args, "Args must not be null");
+			var solrContext = args.SearchContext as SolrSearchContext;
+			if (solrContext != null)
+			{
+				var overrideMapper = new SynthesisSolrDocumentTypeMapper();
+				overrideMapper.Initialize(args.SearchContext.Index);
+				var mapperExecutionContext = new OverrideExecutionContext<IIndexDocumentPropertyMapper<Dictionary<string, object>>>(overrideMapper);
+				var executionContexts = new List<IExecutionContext>();
+				if (args.ExecutionContext != null) executionContexts.AddRange(args.ExecutionContext);
+				executionContexts.Add(mapperExecutionContext);
+				var m = GetType().GetMethod("GetSolrQueryable", BindingFlags.NonPublic | BindingFlags.Instance).MakeGenericMethod(args.SynthesisQueryType);
+				args.SynthesisQueryable = (IQueryable)m.Invoke(this, new object[] { solrContext, executionContexts.ToArray() });
+			}
+			else
+				throw new NotImplementedException("A Solr index is not being used, if you're using Lucene make sure that you're not overridding the synthesisSearchContext pipeline with the Solr processor");
+
+		}
+		private IQueryable<TResult> GetSolrQueryable<TResult>(SolrSearchContext context, IExecutionContext[] executionContext)
+			where TResult : IStandardTemplateItem
+		{
+			var linqToSolrIndex = new SynthesisLinqToSolrIndex<TResult>(context, executionContext);
+
+			if (context.Index.Locator.GetInstance<IContentSearchConfigurationSettings>().EnableSearchDebug())
+				((IHasTraceWriter)linqToSolrIndex).TraceWriter = new LoggingTraceWriter(SearchLog.Log);
+			return linqToSolrIndex.GetQueryable();
+		}
+	}
+}

--- a/Source/Synthesis.Solr/Properties/AssemblyInfo.cs
+++ b/Source/Synthesis.Solr/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyTitle("Synthesis.Solr")]
+[assembly: AssemblyDescription("Synthesis Solr Support")]

--- a/Source/Synthesis.Solr/Properties/SharedAssemblyInfo.cs
+++ b/Source/Synthesis.Solr/Properties/SharedAssemblyInfo.cs
@@ -1,0 +1,12 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using System;
+
+[assembly: AssemblyCompany("ISITE Design")]
+[assembly: AssemblyProduct("Synthesis")]
+[assembly: AssemblyCopyright("Copyright © Kam Figy, ISITE Design")]
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("8.1.1.0")]
+[assembly: AssemblyFileVersion("8.1.1.0")]
+[assembly: AssemblyInformationalVersion("8.1.1")]
+[assembly: CLSCompliant(false)]

--- a/Source/Synthesis.Solr/Standard Config Files/Synthesis.Solr.Config
+++ b/Source/Synthesis.Solr/Standard Config Files/Synthesis.Solr.Config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0"?>
+
+<!--
+	SYNTHESIS CONFIGURATION
+	
+	This file provides general configuration for the Synthesis mapping framework.
+-->
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:set="http://www.sitecore.net/xmlconfig/set/">
+	<sitecore>
+		<services>
+			<!-- 
+				SEARCH CONTEXT RESOLVER
+				Synthesis will use this pipeline to resolve the search queryable for the current search index.
+			-->
+			<register serviceType="Synthesis.ContentSearch.IQueryableResolver, Synthesis" set:implementationType="Synthesis.Solr.ContentSearch.Solr.ResolveSolrQueryable, Synthesis.Solr" />
+		</services>
+	</sitecore>
+</configuration>

--- a/Source/Synthesis.Solr/Synthesis.Solr.csproj
+++ b/Source/Synthesis.Solr/Synthesis.Solr.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Sitecore.ContentSearch, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Sitecore.ContentSearch.NoReferences.8.2.170407\lib\NET452\Sitecore.ContentSearch.dll</HintPath>
       <Private>True</Private>
@@ -51,8 +55,9 @@
       <HintPath>..\..\packages\Sitecore.Kernel.NoReferences.8.2.170407\lib\NET452\Sitecore.Kernel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SolrNet">
-      <HintPath>..\..\Dependencies\Libraries\Sitecore\SolrNet.dll</HintPath>
+    <Reference Include="SolrNet, Version=0.4.0.4001, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SolrNet.0.4.0.4001\lib\SolrNet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -66,20 +71,24 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ContentSearch\Solr\ResolveSolrQueryable.cs" />
     <Compile Include="ContentSearch\SynthesisLinqToSolrIndex.cs" />
     <Compile Include="ContentSearch\SynthesisSolrDocumentTypeMapper.cs" />
     <Compile Include="ContentSearch\SynthesisSolrFieldNameTranslator.cs" />
-    <Compile Include="Pipelines\ContentSearch\ResolveSolrQueryable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Standard Config Files\Synthesis.Solr.Config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Synthesis\Synthesis.csproj">
       <Project>{EBAE2C10-079D-4EB1-9E46-82CEC35D7F4B}</Project>
       <Name>Synthesis</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Pipelines\ContentSearch\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/Synthesis.Solr/Synthesis.Solr.csproj
+++ b/Source/Synthesis.Solr/Synthesis.Solr.csproj
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Synthesis.Solr</RootNamespace>
+    <AssemblyName>Synthesis.Solr</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Practices.ServiceLocation">
+      <HintPath>..\Dependencies\Libraries\Sitecore\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch">
+      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch.Linq">
+      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch.Linq.Solr">
+      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.Linq.Solr.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.ContentSearch.SolrProvider">
+      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.SolrProvider.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Kernel">
+      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.Kernel.dll</HintPath>
+    </Reference>
+    <Reference Include="SolrNet">
+      <HintPath>..\Dependencies\Libraries\Sitecore\SolrNet.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="ContentSearch\SynthesisLinqToSolrIndex.cs" />
+    <Compile Include="ContentSearch\SynthesisSolrDocumentTypeMapper.cs" />
+    <Compile Include="ContentSearch\SynthesisSolrFieldNameTranslator.cs" />
+    <Compile Include="Pipelines\ContentSearch\ResolveSolrQueryable.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Synthesis\Synthesis.csproj">
+      <Project>{EBAE2C10-079D-4EB1-9E46-82CEC35D7F4B}</Project>
+      <Name>Synthesis</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Synthesis.Solr/Synthesis.Solr.csproj
+++ b/Source/Synthesis.Solr/Synthesis.Solr.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Synthesis.Solr</RootNamespace>
     <AssemblyName>Synthesis.Solr</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,26 +31,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation">
-      <HintPath>..\Dependencies\Libraries\Sitecore\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="Sitecore.ContentSearch, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sitecore.ContentSearch.NoReferences.8.2.170407\lib\NET452\Sitecore.ContentSearch.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.ContentSearch">
-      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.dll</HintPath>
+    <Reference Include="Sitecore.ContentSearch.Linq, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sitecore.ContentSearch.Linq.NoReferences.8.2.170407\lib\NET452\Sitecore.ContentSearch.Linq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.ContentSearch.Linq">
-      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.Linq.dll</HintPath>
+    <Reference Include="Sitecore.ContentSearch.Linq.Solr, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sitecore.ContentSearch.Linq.Solr.NoReferences.8.2.170407\lib\NET452\Sitecore.ContentSearch.Linq.Solr.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.ContentSearch.Linq.Solr">
-      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.Linq.Solr.dll</HintPath>
+    <Reference Include="Sitecore.ContentSearch.SolrProvider, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sitecore.ContentSearch.SolrProvider.NoReferences.8.2.170407\lib\NET452\Sitecore.ContentSearch.SolrProvider.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Sitecore.ContentSearch.SolrProvider">
-      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.SolrProvider.dll</HintPath>
-    </Reference>
-    <Reference Include="Sitecore.Kernel">
-      <HintPath>..\Dependencies\Libraries\Sitecore\Sitecore.Kernel.dll</HintPath>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Sitecore.Kernel.NoReferences.8.2.170407\lib\NET452\Sitecore.Kernel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SolrNet">
-      <HintPath>..\Dependencies\Libraries\Sitecore\SolrNet.dll</HintPath>
+      <HintPath>..\..\Dependencies\Libraries\Sitecore\SolrNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/Synthesis.Solr/Synthesis.Solr.nuspec
+++ b/Source/Synthesis.Solr/Synthesis.Solr.nuspec
@@ -1,20 +1,20 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Synthesis.Testing</id>
+    <id>Synthesis.Solr.Core</id>
     <version>$version$</version>
-    <authors>Ben Lipson,Kam Figy</authors>
+    <authors>Ben Lipson,Kam Figy,Jeff Darchuk</authors>
     <owners>Connective DX</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
     <projectUrl>https://github.com/blipson89/Synthesis</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
-		Utilities to assist in unit testing with Synthesis
-	</description>
+		  Adds Solr support to Synthesis. This package contains the core library for class libraries. Use Synthesis.Solr to include configuration.
+	  </description>
     <copyright>Copyright 2017 Ben Lipson/Connective DX</copyright>
-    <tags>sitecore</tags>
+    <tags>sitecore,synthesis,solr</tags>
     <dependencies>
-		<dependency id="Synthesis.Core" version="$version$" />
+      <dependency id="Synthesis" version="$version$" />
     </dependencies>
   </metadata>
   <files>

--- a/Source/Synthesis.Solr/packages.config
+++ b/Source/Synthesis.Solr/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommonServiceLocator" version="1.0" targetFramework="net452" developmentDependency="true" />
   <package id="Sitecore.ContentSearch.Linq.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
   <package id="Sitecore.ContentSearch.Linq.Solr.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
   <package id="Sitecore.ContentSearch.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
   <package id="Sitecore.ContentSearch.SolrProvider.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
   <package id="Sitecore.Kernel.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
+  <package id="SolrNet" version="0.4.0.4001" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Source/Synthesis.Solr/packages.config
+++ b/Source/Synthesis.Solr/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Sitecore.ContentSearch.Linq.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.ContentSearch.Linq.Solr.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.ContentSearch.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.ContentSearch.SolrProvider.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.170407" targetFramework="net452" developmentDependency="true" />
+</packages>

--- a/Source/Synthesis.Tests/Fixtures/ContentSearch/ContentSearchQueryExtensionTests.cs
+++ b/Source/Synthesis.Tests/Fixtures/ContentSearch/ContentSearchQueryExtensionTests.cs
@@ -30,6 +30,7 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 			}
 		}
 
+
 		[Test]
 		public void ContentSearch_FindsSecurityFolderOrRenderingOptions_WhenContainsOrIsUsed()
 		{
@@ -45,5 +46,7 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 				Assert.IsTrue(query.Any(x => x.Name == listOfNames[1]), "ContainsOr result contained no rendering options item");
 			}
 		}
+
+
 	}
 }

--- a/Source/Synthesis.Tests/Fixtures/ContentSearch/FieldTypeTests.cs
+++ b/Source/Synthesis.Tests/Fixtures/ContentSearch/FieldTypeTests.cs
@@ -138,7 +138,7 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 				Assert.IsTrue(facets.Categories.Count > 0, "No valid facets found");
 				Assert.IsTrue(facets.Categories.First().Values.Count > 0, "No valid facet values found");
 
-				Assert.IsTrue(facets.Categories.SelectMany(x => x.Values).All(x => x.Name.StartsWith("T", StringComparison.OrdinalIgnoreCase)), "Facets had items without the specified text value!");
+				Assert.IsTrue(facets.Categories.SelectMany(x => x.Values).All(x => x.Name.StartsWith("T", StringComparison.OrdinalIgnoreCase) || x.AggregateCount == 0), "Facets had items without the specified text value!");
 			});
 		}
 
@@ -148,7 +148,7 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 			{
 				using (new InitializerForcer(new SearchTemplateItemInitializer()))
 				{
-					testBody(context.GetSynthesisQueryable<ISearchTemplateItem>(useStandardFilters));
+						testBody(context.GetSynthesisQueryable<ISearchTemplateItem>(useStandardFilters));
 				}
 			}
 		}

--- a/Source/Synthesis.Tests/Fixtures/ContentSearch/StandardTemplateTests.cs
+++ b/Source/Synthesis.Tests/Fixtures/ContentSearch/StandardTemplateTests.cs
@@ -73,6 +73,8 @@ namespace Synthesis.Tests.Fixtures.ContentSearch
 			}
 		}
 
+
+
 		[Test]
 		public void ContentSearch_FindsChildren_ByParentId()
 		{

--- a/Source/Synthesis.Tests/Synthesis.Tests.csproj
+++ b/Source/Synthesis.Tests/Synthesis.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -54,6 +54,10 @@
     <Reference Include="Sitecore.ContentSearch.Linq, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Sitecore.ContentSearch.Linq.NoReferences.8.2.170407\lib\NET452\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="Sitecore.ContentSearch.LuceneProvider, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Dependencies\Libraries\Sitecore\Sitecore.ContentSearch.LuceneProvider.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Sitecore.Kernel.NoReferences.8.2.170407\lib\NET452\Sitecore.Kernel.dll</HintPath>
     </Reference>
@@ -101,6 +105,10 @@
     <Compile Include="Utility\FieldTestTemplateCreator.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Synthesis.Solr\Synthesis.Solr.csproj">
+      <Project>{d76ce576-81d7-4bda-b6eb-7e5b72c0bcc5}</Project>
+      <Name>Synthesis.Solr</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Synthesis\Synthesis.csproj">
       <Project>{EBAE2C10-079D-4EB1-9E46-82CEC35D7F4B}</Project>
       <Name>Synthesis</Name>
@@ -114,6 +122,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="_HOW TO TEST.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/Synthesis/ContentSearch/IQueryableResolver.cs
+++ b/Source/Synthesis/ContentSearch/IQueryableResolver.cs
@@ -1,0 +1,11 @@
+﻿using System.Linq;
+using Synthesis.Pipelines;
+
+namespace Synthesis.ContentSearch
+{
+	public interface IQueryableResolver
+	{
+		IQueryable<TResult> GetSynthesisQueryable<TResult>(SynthesisSearchContextArgs args)
+			where TResult : IStandardTemplateItem;
+	}
+}

--- a/Source/Synthesis/ContentSearch/Lucene/ResolveLuceneQueryable.cs
+++ b/Source/Synthesis/ContentSearch/Lucene/ResolveLuceneQueryable.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Lucene.Net.Documents;
 using Sitecore.ContentSearch;
 using Sitecore.ContentSearch.Diagnostics;
@@ -9,35 +8,30 @@ using Sitecore.ContentSearch.Linq.Common;
 using Sitecore.ContentSearch.LuceneProvider;
 using Sitecore.ContentSearch.Utilities;
 using Sitecore.Diagnostics;
-using Synthesis.ContentSearch.Lucene;
+using Synthesis.Pipelines;
 
-namespace Synthesis.Pipelines.ContentSearch
+namespace Synthesis.ContentSearch.Lucene
 {
-	public class ResolveLuceneQueryable
+	public class ResolveLuceneQueryable : IQueryableResolver
 	{
-		public void Process(SynthesisSearchContextArgs args)
+		public IQueryable<TResult> GetSynthesisQueryable<TResult>(SynthesisSearchContextArgs args) where TResult : IStandardTemplateItem
 		{
 			Assert.IsNotNull(args, "Args must not be null");
 			var luceneContext = args.SearchContext as LuceneSearchContext;
 
-			if (luceneContext != null)
-			{
-				var overrideMapper = new SynthesisLuceneDocumentTypeMapper();
-				overrideMapper.Initialize(args.SearchContext.Index);
-
-				var mapperExecutionContext = new OverrideExecutionContext<IIndexDocumentPropertyMapper<Document>>(overrideMapper);
-				var executionContexts = new List<IExecutionContext>();
-				if (args.ExecutionContext != null) executionContexts.AddRange(args.ExecutionContext);
-				executionContexts.Add(mapperExecutionContext);
-				var m = GetType().GetMethod("GetLuceneQueryable",BindingFlags.NonPublic | BindingFlags.Instance).MakeGenericMethod(args.SynthesisQueryType);
-				args.SynthesisQueryable = (IQueryable)m.Invoke(this, new object[] { luceneContext, executionContexts.ToArray() });
-			}
-			else
-			{
+			if (luceneContext == null)
 				throw new NotImplementedException("A Lucene index is not being used, if you're using Solr make sure that you're overridding the synthesisSearchContext pipeline with the Solr processor in Synthesis.Solr");
-			}
 
+			var overrideMapper = new SynthesisLuceneDocumentTypeMapper();
+			overrideMapper.Initialize(args.SearchContext.Index);
+
+			var mapperExecutionContext = new OverrideExecutionContext<IIndexDocumentPropertyMapper<Document>>(overrideMapper);
+			var executionContexts = new List<IExecutionContext>();
+			if (args.ExecutionContext != null) executionContexts.AddRange(args.ExecutionContext);
+			executionContexts.Add(mapperExecutionContext);
+			return GetLuceneQueryable<TResult>(luceneContext, executionContexts.ToArray());
 		}
+
 		private IQueryable<TResult> GetLuceneQueryable<TResult>(LuceneSearchContext context, IExecutionContext[] executionContext)
 	where TResult : IStandardTemplateItem
 		{

--- a/Source/Synthesis/ContentSearchExtensions.cs
+++ b/Source/Synthesis/ContentSearchExtensions.cs
@@ -2,16 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Lucene.Net.Documents;
+using Sitecore;
 using Sitecore.ContentSearch;
-using Sitecore.ContentSearch.Diagnostics;
 using Sitecore.ContentSearch.Linq.Common;
-using Sitecore.ContentSearch.LuceneProvider;
-using Sitecore.ContentSearch.Utilities;
 using Sitecore.Data;
 using Sitecore.Data.Items;
 using Sitecore.Exceptions;
-using Synthesis.ContentSearch.Lucene;
+using Sitecore.Pipelines;
+using Synthesis.Pipelines;
 using Synthesis.Synchronization;
 
 namespace Synthesis
@@ -54,31 +52,17 @@ namespace Synthesis
 		public static IQueryable<TResult> GetSynthesisQueryable<TResult>(this IProviderSearchContext context, bool applyStandardFilters, params IExecutionContext[] executionContext)
 			where TResult : IStandardTemplateItem
 		{
-			IQueryable<TResult> queryable;
-
-			var luceneContext = context as LuceneSearchContext;
-
-			if (luceneContext != null)
+			var args = new SynthesisSearchContextArgs
 			{
-				var overrideMapper = new SynthesisLuceneDocumentTypeMapper();
-				overrideMapper.Initialize(context.Index);
-
-				var mapperExecutionContext = new OverrideExecutionContext<IIndexDocumentPropertyMapper<Document>>(overrideMapper);
-				var executionContexts = new List<IExecutionContext>();
-				if (executionContext != null) executionContexts.AddRange(executionContext);
-				executionContexts.Add(mapperExecutionContext);
-
-				queryable = GetLuceneQueryable<TResult>(luceneContext, executionContexts.ToArray());
-			}
-			else
-			{
-				// TODO: possible SOLR support with different mapper
-				throw new NotImplementedException("At this time Synthesis only supports Lucene indexes.");
-			}
-
-			if (applyStandardFilters) queryable = queryable.ApplyStandardFilters();
-
-			return queryable;
+				SearchContext = context,
+				ExecutionContext = executionContext,
+				SynthesisQueryType = typeof (TResult)
+			};
+			var pipeline = CorePipelineFactory.GetPipeline("synthesisQueryable", string.Empty);
+			pipeline.Run(args);
+			var result = (IQueryable<TResult>)args.SynthesisQueryable;
+			if (applyStandardFilters) result = result.ApplyStandardFilters();
+			return result;
 		}
 
 		/// <summary>
@@ -91,7 +75,7 @@ namespace Synthesis
 			where TResult : IStandardTemplateItem
 		{
 
-			var language = (Sitecore.Context.Item != null) ? Sitecore.Context.Item.Language : Sitecore.Context.Language;
+			var language = (Context.Item != null) ? Context.Item.Language : Context.Language;
 
 			var subquery = query.Where(x => x.Language == language && x.IsLatestVersion);
 
@@ -166,16 +150,7 @@ namespace Synthesis
 			}
 		}
 
-		private static IQueryable<TResult> GetLuceneQueryable<TResult>(LuceneSearchContext context, IExecutionContext[] executionContext)
-			where TResult : IStandardTemplateItem
-		{
-			var linqToLuceneIndex = new SynthesisLinqToLuceneIndex<TResult>(context, executionContext);
 
-			if (context.Index.Locator.GetInstance<IContentSearchConfigurationSettings>().EnableSearchDebug())
-				((IHasTraceWriter)linqToLuceneIndex).TraceWriter = new LoggingTraceWriter(SearchLog.Log);
-
-			return linqToLuceneIndex.GetQueryable();
-		}
 
 		private static ID GetTemplateId(Type synthesisType)
 		{

--- a/Source/Synthesis/ContentSearchExtensions.cs
+++ b/Source/Synthesis/ContentSearchExtensions.cs
@@ -7,8 +7,10 @@ using Sitecore.ContentSearch;
 using Sitecore.ContentSearch.Linq.Common;
 using Sitecore.Data;
 using Sitecore.Data.Items;
+using Sitecore.DependencyInjection;
 using Sitecore.Exceptions;
 using Sitecore.Pipelines;
+using Synthesis.ContentSearch;
 using Synthesis.Pipelines;
 using Synthesis.Synchronization;
 
@@ -16,6 +18,8 @@ namespace Synthesis
 {
 	public static class ContentSearchExtensions
 	{
+		private static readonly LazyResetable<IQueryableResolver> QueryableResolver = ServiceLocator.GetRequiredResetableService<IQueryableResolver>();
+
 		/// <summary>
 		/// Gets a queryable for Synthesis items (supports querying on interfaces, unlike the standard method)
 		/// </summary>
@@ -55,12 +59,9 @@ namespace Synthesis
 			var args = new SynthesisSearchContextArgs
 			{
 				SearchContext = context,
-				ExecutionContext = executionContext,
-				SynthesisQueryType = typeof (TResult)
+				ExecutionContext = executionContext
 			};
-			var pipeline = CorePipelineFactory.GetPipeline("synthesisQueryable", string.Empty);
-			pipeline.Run(args);
-			var result = (IQueryable<TResult>)args.SynthesisQueryable;
+			var result = QueryableResolver.Value.GetSynthesisQueryable<TResult>(args);
 			if (applyStandardFilters) result = result.ApplyStandardFilters();
 			return result;
 		}

--- a/Source/Synthesis/FieldTypes/DateTimeField.cs
+++ b/Source/Synthesis/FieldTypes/DateTimeField.cs
@@ -21,8 +21,14 @@ namespace Synthesis.FieldTypes
 			{
 				if (!IsFieldLoaded && InnerSearchValue != null)
 				{
+					DateTime ret;
+					if (DateTime.TryParse(InnerSearchValue, out ret))
+						return ret;
+					if (DateTime.TryParseExact(InnerSearchValue, "yyyyMMdd'T'HHmm'Z'", CultureInfo.CurrentCulture,
+						DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out ret))
+						return ret;
 					var converter = new IndexFieldDateTimeValueConverter();
-					// ReSharper disable once PossibleNullReferenceException
+					//// ReSharper disable once PossibleNullReferenceException
 					return (DateTime)converter.ConvertFrom(InnerSearchValue);
 				}
 

--- a/Source/Synthesis/Generation/MetadataGenerator.cs
+++ b/Source/Synthesis/Generation/MetadataGenerator.cs
@@ -63,7 +63,7 @@ namespace Synthesis.Generation
 
 						if (_parameters.EnableContentSearch)
 						{
-							fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field); // new
+							fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field);
 						}
 						fieldInfo.FieldType = _fieldMappingProvider.GetFieldType(field);
 

--- a/Source/Synthesis/Generation/MetadataGenerator.cs
+++ b/Source/Synthesis/Generation/MetadataGenerator.cs
@@ -60,15 +60,11 @@ namespace Synthesis.Generation
 
 						var fieldInfo = new FieldPropertyInfo(field);
 						fieldInfo.FieldPropertyName = propertyName;
-						
+
 						if (_parameters.EnableContentSearch)
 						{
-						if (_indexFieldNameTranslator.GetType().Name.ToLower().Contains("solr"))
-							SolrFieldMappingHack(field, fieldInfo);
-						else
 							fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field); // new
-							fieldInfo.SearchFieldName = _indexFieldNameTranslator.GetIndexFieldName(field.Name); //jeff
-}
+						}
 						fieldInfo.FieldType = _fieldMappingProvider.GetFieldType(field);
 
 						if (fieldInfo.FieldType == null)
@@ -140,11 +136,7 @@ namespace Synthesis.Generation
 					fieldInfo.FieldPropertyName = propertyName;
 					if (_parameters.EnableContentSearch)
 					{
-					if (_indexFieldNameTranslator.GetType().Name.ToLower().Contains("solr"))
-						SolrFieldMappingHack(field, fieldInfo);
-					else
-						fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field); //new
-						fieldInfo.SearchFieldName = _indexFieldNameTranslator.GetIndexFieldName(field.Name); //jeff
+						fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field);
 					}
 					fieldInfo.FieldType = _fieldMappingProvider.GetFieldType(field);
 
@@ -176,28 +168,7 @@ namespace Synthesis.Generation
 
 			return interfaceInfo;
 		}
-		/// <summary>
-		/// Evil hack!
-		/// the sitecore solr field mapper has everything we need to identify the dynamic fields, however they dont expose them publicly.
-		/// This hack is to gain access to the method GetFieldConfigurationByFieldTypeName which is essentailly a mapping of sitecore type
-		/// to solr type (I.E. "Rich Text" -> "{0}_t").  This method lives in the SolrFieldMap field on the SolrFieldNameTranslator class
-		/// which is what we have here as the _indexFieldNameTranslator.
-		/// </summary>
-		/// <param name="field"></param>
-		/// <param name="fieldInfo"></param>
-		private void SolrFieldMappingHack(ITemplateFieldInfo field, FieldPropertyInfo fieldInfo)
-		{
-			var hack = _indexFieldNameTranslator.GetType().GetField("fieldMap", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(_indexFieldNameTranslator);
-			var hackPartTwo = hack.GetType().GetMethod("GetFieldConfigurationByFieldTypeName").Invoke(hack, new object[] { field.Type });
-			if (hackPartTwo != null)
-			{
-				var settings = _indexFieldNameTranslator.GetType().GetField("settings", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(_indexFieldNameTranslator);
-				var schema = _indexFieldNameTranslator.GetType().GetField("schema", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(_indexFieldNameTranslator);
-				fieldInfo.SearchFieldName = hackPartTwo.GetType().GetMethod("FormatFieldName", new[] { typeof(string), typeof(Sitecore.ContentSearch.ISearchIndexSchema), typeof(string), typeof(string) }).Invoke(hackPartTwo, new object[] { field.Name, schema, null, settings.GetType().GetMethod("DefaultLanguage").Invoke(settings, null) }).ToString();
-			}
-			else
-				fieldInfo.SearchFieldName = _indexFieldNameTranslator.GetIndexFieldName(field.Name) + "_t";
-		}
+	
 		/// <summary>
 		/// Gets the writeable property names defined in the item base class (normally StandardTemplateItem) so we generate unique field names for any fields that have the same names as these
 		/// </summary>

--- a/Source/Synthesis/Generation/MetadataGenerator.cs
+++ b/Source/Synthesis/Generation/MetadataGenerator.cs
@@ -5,6 +5,7 @@ using Synthesis.ContentSearch;
 using Synthesis.FieldTypes;
 using Synthesis.Generation.Model;
 using Synthesis.Templates;
+using System.Reflection;
 
 namespace Synthesis.Generation
 {
@@ -21,7 +22,7 @@ namespace Synthesis.Generation
 		{
 			parameters.Validate();
 			_parameters = parameters;
-
+			
 			_templateInputProvider = templateProvider;
 			_fieldMappingProvider = fieldMappingProvider;
 			_indexFieldNameMapper = indexFieldNameMapper;
@@ -58,14 +59,16 @@ namespace Synthesis.Generation
 						string propertyName = field.Name.AsNovelIdentifier(fieldKeys);
 
 						var fieldInfo = new FieldPropertyInfo(field);
-
 						fieldInfo.FieldPropertyName = propertyName;
-
+						
 						if (_parameters.EnableContentSearch)
 						{
-							fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field);
-						}
-
+						if (_indexFieldNameTranslator.GetType().Name.ToLower().Contains("solr"))
+							SolrFieldMappingHack(field, fieldInfo);
+						else
+							fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field); // new
+							fieldInfo.SearchFieldName = _indexFieldNameTranslator.GetIndexFieldName(field.Name); //jeff
+}
 						fieldInfo.FieldType = _fieldMappingProvider.GetFieldType(field);
 
 						if (fieldInfo.FieldType == null)
@@ -135,12 +138,14 @@ namespace Synthesis.Generation
 
 					var fieldInfo = new FieldPropertyInfo(field);
 					fieldInfo.FieldPropertyName = propertyName;
-
 					if (_parameters.EnableContentSearch)
 					{
-						fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field);
+					if (_indexFieldNameTranslator.GetType().Name.ToLower().Contains("solr"))
+						SolrFieldMappingHack(field, fieldInfo);
+					else
+						fieldInfo.SearchFieldName = _indexFieldNameMapper.MapToSearchField(field); //new
+						fieldInfo.SearchFieldName = _indexFieldNameTranslator.GetIndexFieldName(field.Name); //jeff
 					}
-
 					fieldInfo.FieldType = _fieldMappingProvider.GetFieldType(field);
 
 					if (fieldInfo.FieldType == null)
@@ -171,7 +176,28 @@ namespace Synthesis.Generation
 
 			return interfaceInfo;
 		}
-
+		/// <summary>
+		/// Evil hack!
+		/// the sitecore solr field mapper has everything we need to identify the dynamic fields, however they dont expose them publicly.
+		/// This hack is to gain access to the method GetFieldConfigurationByFieldTypeName which is essentailly a mapping of sitecore type
+		/// to solr type (I.E. "Rich Text" -> "{0}_t").  This method lives in the SolrFieldMap field on the SolrFieldNameTranslator class
+		/// which is what we have here as the _indexFieldNameTranslator.
+		/// </summary>
+		/// <param name="field"></param>
+		/// <param name="fieldInfo"></param>
+		private void SolrFieldMappingHack(ITemplateFieldInfo field, FieldPropertyInfo fieldInfo)
+		{
+			var hack = _indexFieldNameTranslator.GetType().GetField("fieldMap", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(_indexFieldNameTranslator);
+			var hackPartTwo = hack.GetType().GetMethod("GetFieldConfigurationByFieldTypeName").Invoke(hack, new object[] { field.Type });
+			if (hackPartTwo != null)
+			{
+				var settings = _indexFieldNameTranslator.GetType().GetField("settings", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(_indexFieldNameTranslator);
+				var schema = _indexFieldNameTranslator.GetType().GetField("schema", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(_indexFieldNameTranslator);
+				fieldInfo.SearchFieldName = hackPartTwo.GetType().GetMethod("FormatFieldName", new[] { typeof(string), typeof(Sitecore.ContentSearch.ISearchIndexSchema), typeof(string), typeof(string) }).Invoke(hackPartTwo, new object[] { field.Name, schema, null, settings.GetType().GetMethod("DefaultLanguage").Invoke(settings, null) }).ToString();
+			}
+			else
+				fieldInfo.SearchFieldName = _indexFieldNameTranslator.GetIndexFieldName(field.Name) + "_t";
+		}
 		/// <summary>
 		/// Gets the writeable property names defined in the item base class (normally StandardTemplateItem) so we generate unique field names for any fields that have the same names as these
 		/// </summary>

--- a/Source/Synthesis/Pipelines/ContentSearch/ResolveLuceneQueryable.cs
+++ b/Source/Synthesis/Pipelines/ContentSearch/ResolveLuceneQueryable.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Lucene.Net.Documents;
+using Sitecore.ContentSearch;
+using Sitecore.ContentSearch.Diagnostics;
+using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.ContentSearch.LuceneProvider;
+using Sitecore.ContentSearch.Utilities;
+using Sitecore.Diagnostics;
+using Synthesis.ContentSearch.Lucene;
+
+namespace Synthesis.Pipelines.ContentSearch
+{
+	public class ResolveLuceneQueryable
+	{
+		public void Process(SynthesisSearchContextArgs args)
+		{
+			Assert.IsNotNull(args, "Args must not be null");
+			var luceneContext = args.SearchContext as LuceneSearchContext;
+
+			if (luceneContext != null)
+			{
+				var overrideMapper = new SynthesisLuceneDocumentTypeMapper();
+				overrideMapper.Initialize(args.SearchContext.Index);
+
+				var mapperExecutionContext = new OverrideExecutionContext<IIndexDocumentPropertyMapper<Document>>(overrideMapper);
+				var executionContexts = new List<IExecutionContext>();
+				if (args.ExecutionContext != null) executionContexts.AddRange(args.ExecutionContext);
+				executionContexts.Add(mapperExecutionContext);
+				var m = GetType().GetMethod("GetLuceneQueryable",BindingFlags.NonPublic | BindingFlags.Instance).MakeGenericMethod(args.SynthesisQueryType);
+				args.SynthesisQueryable = (IQueryable)m.Invoke(this, new object[] { luceneContext, executionContexts.ToArray() });
+			}
+			else
+			{
+				throw new NotImplementedException("A Lucene index is not being used, if you're using Solr make sure that you're overridding the synthesisSearchContext pipeline with the Solr processor in Synthesis.Solr");
+			}
+
+		}
+		private IQueryable<TResult> GetLuceneQueryable<TResult>(LuceneSearchContext context, IExecutionContext[] executionContext)
+	where TResult : IStandardTemplateItem
+		{
+			var linqToLuceneIndex = new SynthesisLinqToLuceneIndex<TResult>(context, executionContext);
+
+			if (context.Index.Locator.GetInstance<IContentSearchConfigurationSettings>().EnableSearchDebug())
+				((IHasTraceWriter)linqToLuceneIndex).TraceWriter = new LoggingTraceWriter(SearchLog.Log);
+
+			return linqToLuceneIndex.GetQueryable();
+		}
+	}
+}

--- a/Source/Synthesis/Pipelines/SynthesisSearchContextArgs.cs
+++ b/Source/Synthesis/Pipelines/SynthesisSearchContextArgs.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Sitecore.ContentSearch;
+﻿using Sitecore.ContentSearch;
 using Sitecore.ContentSearch.Linq.Common;
 using Sitecore.Pipelines;
 
@@ -8,9 +6,7 @@ namespace Synthesis.Pipelines
 {
 	public class SynthesisSearchContextArgs : PipelineArgs
 	{
-		public IQueryable SynthesisQueryable { get; set; }
 		public IExecutionContext[] ExecutionContext { get; set; }
 		public IProviderSearchContext SearchContext { get; set; }
-		public Type SynthesisQueryType { get; set; }
 	}
 }

--- a/Source/Synthesis/Pipelines/SynthesisSearchContextArgs.cs
+++ b/Source/Synthesis/Pipelines/SynthesisSearchContextArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Linq;
+using Sitecore.ContentSearch;
+using Sitecore.ContentSearch.Linq.Common;
+using Sitecore.Pipelines;
+
+namespace Synthesis.Pipelines
+{
+	public class SynthesisSearchContextArgs : PipelineArgs
+	{
+		public IQueryable SynthesisQueryable { get; set; }
+		public IExecutionContext[] ExecutionContext { get; set; }
+		public IProviderSearchContext SearchContext { get; set; }
+		public Type SynthesisQueryType { get; set; }
+	}
+}

--- a/Source/Synthesis/Standard Config Files/Synthesis.config
+++ b/Source/Synthesis/Standard Config Files/Synthesis.config
@@ -339,6 +339,15 @@
 					</assemblies>
 				</processor>
 			</initialize>
+			<synthesisQueryable>
+				<!--Search context resolver
+					Synthesis will use this pipeline to resolve the search queryable for the current search index.
+					
+					for Solr make sure you have the solr support package and uncomment out the following processor and comment out the lucene processor.
+				-->
+				<!--<processor type="Synthesis.Solr.Pipelines.ContentSearch.ResolveSolrQueryable, Synthesis.Solr" />-->
+				<processor type="Synthesis.Pipelines.ContentSearch.ResolveLuceneQueryable, Synthesis" />
+				</synthesisQueryable>
 		</pipelines>
 		<contentSearch>
 			<indexConfigurations>

--- a/Source/Synthesis/Standard Config Files/Synthesis.config
+++ b/Source/Synthesis/Standard Config Files/Synthesis.config
@@ -339,16 +339,15 @@
 					</assemblies>
 				</processor>
 			</initialize>
-			<synthesisQueryable>
-				<!--Search context resolver
-					Synthesis will use this pipeline to resolve the search queryable for the current search index.
-					
-					for Solr make sure you have the solr support package and uncomment out the following processor and comment out the lucene processor.
-				-->
-				<!--<processor type="Synthesis.Solr.Pipelines.ContentSearch.ResolveSolrQueryable, Synthesis.Solr" />-->
-				<processor type="Synthesis.Pipelines.ContentSearch.ResolveLuceneQueryable, Synthesis" />
-				</synthesisQueryable>
 		</pipelines>
+		<services>
+			<!-- 
+				SEARCH CONTEXT RESOLVER
+				Synthesis will use this pipeline to resolve the search queryable for the current search index.
+			-->
+			<register serviceType="Synthesis.ContentSearch.IQueryableResolver, Synthesis" implementationType="Synthesis.ContentSearch.Lucene.ResolveLuceneQueryable, Synthesis" lifetime="Singleton" />
+		</services>
+		
 		<contentSearch>
 			<indexConfigurations>
 				<defaultLuceneIndexConfiguration>

--- a/Source/Synthesis/Synthesis.csproj
+++ b/Source/Synthesis/Synthesis.csproj
@@ -144,9 +144,11 @@
     <Compile Include="ItemExtensions.cs" />
     <Compile Include="Initializers\ITemplateInitializer.cs" />
     <Compile Include="MissingTemplateFieldException.cs" />
+    <Compile Include="Pipelines\ContentSearch\ResolveLuceneQueryable.cs" />
     <Compile Include="Pipelines\Initialize\CheckModelSynchronization.cs" />
     <Compile Include="Pipelines\Initialize\SynthesisConfigRegistrar.cs" />
     <Compile Include="SynthesisHelper.cs" />
+    <Compile Include="Pipelines\SynthesisSearchContextArgs.cs" />
     <Compile Include="SynthesisEditContext.cs" />
     <Compile Include="Synchronization\ModelTemplateReference.cs" />
     <Compile Include="Synchronization\SyncSource.cs" />

--- a/Source/Synthesis/Synthesis.csproj
+++ b/Source/Synthesis/Synthesis.csproj
@@ -86,6 +86,8 @@
     <Compile Include="ContentSearch\ComputedFields\InheritedTemplates.cs" />
     <Compile Include="ContentSearch\ContentSearchUtilities.cs" />
     <Compile Include="ContentSearch\DocumentMappingResult.cs" />
+    <Compile Include="ContentSearch\IQueryableResolver.cs" />
+    <Compile Include="ContentSearch\Lucene\ResolveLuceneQueryable.cs" />
     <Compile Include="ContentSearch\Lucene\SynthesisLinqToLuceneIndex.cs" />
     <Compile Include="ContentSearch\IndexFieldNameMapper.cs" />
     <Compile Include="ContentSearch\SynthesisDocumentTypeMapper.cs" />
@@ -144,7 +146,6 @@
     <Compile Include="ItemExtensions.cs" />
     <Compile Include="Initializers\ITemplateInitializer.cs" />
     <Compile Include="MissingTemplateFieldException.cs" />
-    <Compile Include="Pipelines\ContentSearch\ResolveLuceneQueryable.cs" />
     <Compile Include="Pipelines\Initialize\CheckModelSynchronization.cs" />
     <Compile Include="Pipelines\Initialize\SynthesisConfigRegistrar.cs" />
     <Compile Include="SynthesisHelper.cs" />

--- a/Source/Synthesis/Synthesis.nuspec
+++ b/Source/Synthesis/Synthesis.nuspec
@@ -3,15 +3,15 @@
   <metadata>
     <id>Synthesis.Core</id>
     <version>$version$</version>
-    <authors>Kam Figy</authors>
-    <owners>ISITE Design</owners>
+    <authors>Ben Lipson,Kam Figy</authors>
+    <owners>Connective DX</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
-    <projectUrl>https://github.com/kamsar/Synthesis</projectUrl>
+    <projectUrl>https://github.com/blipson89/Synthesis</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
-		Synthesis is a universal object mapper with LINQ support for Sitecore 8.1. This package contains only the core library, and is suitable for installing to class libraries. For installing to a web project, use the Synthesis package, which comes with configuration files as well.
-	</description>
-    <copyright>Copyright 2015 Kam Figy/Connective DX</copyright>
+      Synthesis is a universal object mapper with LINQ support for Sitecore 8.2. This package contains only the core library, and is suitable for installing to class libraries. For installing to a web project, use the Synthesis package, which comes with configuration files as well.
+    </description>
+    <copyright>Copyright 2017 Ben Lipson/Connective DX</copyright>
     <tags>sitecore</tags>
     <dependencies>
     </dependencies>

--- a/Synthesis.sln
+++ b/Synthesis.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Synthesis.Testing", "Source
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Synthesis.Mvc", "Source\Synthesis.Mvc\Synthesis.Mvc.csproj", "{97C803D2-5E32-4D5C-8ECB-EE49D759A953}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Synthesis.Solr", "Source\Synthesis.Solr\Synthesis.Solr.csproj", "{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{97C803D2-5E32-4D5C-8ECB-EE49D759A953}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97C803D2-5E32-4D5C-8ECB-EE49D759A953}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97C803D2-5E32-4D5C-8ECB-EE49D759A953}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D76CE576-81D7-4BDA-B6EB-7E5B72C0BCC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
From @JeffDarchuk on the [Original PR](https://github.com/blipson89/Synthesis/pull/21):
> essentially copied the Lucene functionality with a few distinct changes in how the documents are managed. This was done in a seperate Synthesis.Solr project to avoid a dependency on solr in the main area of Synthesis. Additionally I've modified the search unit tests so that Lucene and Solr share tests. I believe there are differences in how sitecore sets up the fields in Solr vs Lucene, so some of the unit tests are failing due to unexpected results. Also i changed how the search DateTimeField is acquired since the unit tests were throwing exceptions, this will need review.