### PR TITLE
Move config files to \App_Config\Modules folder

### DIFF
--- a/Build/Synthesis.Mvc.nuget/Synthesis.Mvc.nuspec
+++ b/Build/Synthesis.Mvc.nuget/Synthesis.Mvc.nuspec
@@ -25,9 +25,9 @@
     </contentFiles>
   </metadata>
   <files>
-    <file src="..\..\Source\Synthesis.Mvc\Standard Config Files\*" target="contentFiles\any\any\App_Config\Include\Synthesis" />
+    <file src="..\..\Source\Synthesis.Mvc\Standard Config Files\*" target="contentFiles\any\any\App_Config\Modules\Synthesis" />
 
     <!-- Legacy Support -->
-    <file src="..\..\Source\Synthesis.Mvc\Standard Config Files\Synthesis.Mvc.config" target="content\App_Config\Include\Synthesis" />
+    <file src="..\..\Source\Synthesis.Mvc\Standard Config Files\Synthesis.Mvc.config" target="content\App_Config\Modules\Synthesis" />
   </files>
 </package>

--- a/Build/Synthesis.Solr.nuget/Synthesis.Solr.nuspec
+++ b/Build/Synthesis.Solr.nuget/Synthesis.Solr.nuspec
@@ -25,9 +25,9 @@
     </contentFiles>
   </metadata>
   <files>
-    <file src="..\..\Source\Synthesis.Solr\Standard Config Files\*" target="contentFiles\any\any\App_Config\Include\Synthesis" />
+    <file src="..\..\Source\Synthesis.Solr\Standard Config Files\*" target="contentFiles\any\any\App_Config\Modules\Synthesis" />
 
     <!-- Legacy Support -->
-    <file src="..\..\Source\Synthesis.Solr\Standard Config Files\Synthesis.Solr.config" target="content\App_Config\Include\Synthesis" />
+    <file src="..\..\Source\Synthesis.Solr\Standard Config Files\Synthesis.Solr.config" target="content\App_Config\Modules\Synthesis" />
   </files>
 </package>

--- a/Build/Synthesis.nuget/Synthesis.nuspec
+++ b/Build/Synthesis.nuget/Synthesis.nuspec
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
       Synthesis is a universal object mapper with LINQ support for Sitecore 8.1 and up. Use the same strongly typed objects to run queries against search indexes or the database, or transparently convert from indexed to database when necessary. Supports fully polymorphic Sitecore template inheritance via a generated interface hierarchy.
-      
+
       This package contains both the Synthesis core library and the configuration for it, which is appropriate for web projects. Install Synthesis.Core if you only want the library.
 
       NOTE: Synthesis 9.1.0 and above requires Sitecore 9.1.0 or higher
@@ -29,12 +29,12 @@
     </contentFiles>
   </metadata>
   <files>
-    <file src="..\..\Source\Synthesis\Standard Config Files\Synthesis*.config" target="contentFiles\any\any\App_Config\Include\Synthesis" />
-    <file src="..\..\Source\Synthesis\Standard Config Files\Synthesis*.example" target="contentFiles\any\any\App_Config\Include\Synthesis" />
+    <file src="..\..\Source\Synthesis\Standard Config Files\Synthesis*.config" target="contentFiles\any\any\App_Config\Modules\Synthesis" />
+    <file src="..\..\Source\Synthesis\Standard Config Files\Synthesis*.example" target="contentFiles\any\any\App_Config\Modules\Synthesis" />
     <file src="readme.txt" target="" />
 
     <!-- Legacy Support -->
-    <file src="..\..\Source\Synthesis\Standard Config Files\Synthesis*.config" target="content\App_Config\Include\Synthesis" />
-    <file src="..\..\Source\Synthesis\Standard Config Files\Synthesis*.example" target="content\App_Config\Include\Synthesis" />
+    <file src="..\..\Source\Synthesis\Standard Config Files\Synthesis*.config" target="content\App_Config\Modules\Synthesis" />
+    <file src="..\..\Source\Synthesis\Standard Config Files\Synthesis*.example" target="content\App_Config\Modules\Synthesis" />
   </files>
 </package>


### PR DESCRIPTION
Since Synthesis 9.1.0 and above requires Sitecore 9.1, we can move configs out of the `\App_Config\Include` catch-all folder into the `\App_Config\Modules` folder that was introduced with config layers in Sitecore 9.