### PR TITLE
Bugfix for solr field name translation

### DIFF
--- a/Source/Synthesis.Solr/ContentSearch/SynthesisSolrFieldNameTranslatorFactory.cs
+++ b/Source/Synthesis.Solr/ContentSearch/SynthesisSolrFieldNameTranslatorFactory.cs
@@ -34,7 +34,7 @@ namespace Synthesis.Solr.ContentSearch
 
 
             ICultureContextGuard cultureContextGuard = ObjectActivator.GetActivator<ICultureContextGuard>(ctor).Invoke();
-            return new SynthesisSolrFieldNameTranslator(fieldMap, schema, instance, configurationResolver, new ExtensionStripHelper(fieldMap, schema), typeResolverFactory, cultureContextGuard);
+            return new SynthesisFieldNameTranslator(new SynthesisSolrFieldNameTranslator(fieldMap, schema, instance, configurationResolver, new ExtensionStripHelper(fieldMap, schema), typeResolverFactory, cultureContextGuard));
         }
     }
 }


### PR DESCRIPTION
While trying to use a LINQ query with GetSynthesisQueryable I noticed that the field name translation for solr was not working as intended:
A `query.Where(x => x.Title.RawValue.Contains("xyz"))` was translated to the following solr query: `title_t.rawvalue_t:(*xyz*)` (RawValue was translated too). I solved this by wrapping the `SynthesisSolrFieldNameTranslator` in the regular `SynthesisFieldNameTranslator`, so the "normal" field name translation occurs also when using solr. I hope, this makes sense, but so far I had no issues with it.