### PR TITLE
Temporary fix

### DIFF
--- a/Source/Synthesis.Mvc/Synthesis.Mvc.csproj
+++ b/Source/Synthesis.Mvc/Synthesis.Mvc.csproj
@@ -18,10 +18,10 @@
     <None Remove="Synthesis.Mvc.nuspec" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sitecore.ContentSearch" Version="4.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Sitecore.ExperienceExplorer.Core" Version="4.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Sitecore.Kernel" Version="12.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Sitecore.Mvc" Version="3.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Sitecore.ContentSearch" Version="9.1.0" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Sitecore.ExperienceExplorer.Core" Version="9.1.0" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Sitecore.Kernel" Version="9.1.0" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Sitecore.Mvc" Version="9.1.0" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">

--- a/Source/Synthesis.Solr/Synthesis.Solr.csproj
+++ b/Source/Synthesis.Solr/Synthesis.Solr.csproj
@@ -21,8 +21,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sitecore.ContentSearch.SolrProvider" Version="4.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Sitecore.Kernel" Version="12.0.0" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Sitecore.ContentSearch.SolrProvider" Version="9.1.0" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Sitecore.Kernel" Version="9.1.0" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Synthesis\Synthesis.csproj" />

--- a/Source/Synthesis.Testing/Synthesis.Testing.csproj
+++ b/Source/Synthesis.Testing/Synthesis.Testing.csproj
@@ -12,7 +12,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sitecore.Kernel" Version="12.0.0" />
+    <PackageReference Include="Sitecore.Kernel" Version="9.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Synthesis\Synthesis.csproj" />

--- a/Source/Synthesis.Tests/Synthesis.Tests.csproj
+++ b/Source/Synthesis.Tests/Synthesis.Tests.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="2.6.4" />
-    <PackageReference Include="Sitecore.ContentSearch" Version="4.0.0" />
-    <PackageReference Include="Sitecore.ContentSearch.Linq" Version="4.0.0" />
-    <PackageReference Include="Sitecore.Kernel" Version="12.0.0" />
+    <PackageReference Include="Sitecore.ContentSearch" Version="9.1.0" />
+    <PackageReference Include="Sitecore.ContentSearch.Linq" Version="9.1.0" />
+    <PackageReference Include="Sitecore.Kernel" Version="9.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Synthesis\Synthesis.csproj" />

--- a/Source/Synthesis/Synthesis.csproj
+++ b/Source/Synthesis/Synthesis.csproj
@@ -23,8 +23,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Sitecore.ContentSearch" Version="4.0.0" />
-    <PackageReference Include="Sitecore.ContentSearch.Linq" Version="4.0.0" />
-    <PackageReference Include="Sitecore.Kernel" Version="12.0.0" />
+    <PackageReference Include="Sitecore.ContentSearch" Version="9.1.0" />
+    <PackageReference Include="Sitecore.ContentSearch.Linq" Version="9.1.0" />
+    <PackageReference Include="Sitecore.Kernel" Version="9.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR addresses an issue where fields are not being correctly translated into their Solr equivalent names.

Note the log entries below. 

- "publish_date" should be "publish_date_tdt"
- "topic" should be "topic_sm"
- "tag" should be "tag_sm"
- "content_type.targetid_s" should be "content_type_s"

```
24324 22:47:20 INFO  Solr Query - ?q=(((_language:(en) AND _latestversion:(True)) AND _templatesimplemented_sm:(8894f95e838049379c1b7442a6944115)) AND ((-publish_date.hasvalue_b:(True)  *:*) OR publish_date.value_tdt:{2018-03-18T04:00:00Z TO *]))&rows=3&fl=*,score&fq=((topic:(61318689b2684e998afd8cc913f2fa04) OR tag:(f25e091ed9d14f3588deb79194acead4)) AND content_type.targetid_s:(00000000000000000000000000000000))&fq=_indexname:(sitecore_web_index)&wt=xml&sort=publish_date desc

24324 22:47:26 ERROR Solr Error : ["sort param field can't be found: publish_date"] - Query attempted: [(((_language:(en) AND _latestversion:(True)) AND _templatesimplemented_sm:(8894f95e838049379c1b7442a6944115)) AND ((-publish_date.hasvalue_b:(True)  *:*) OR publish_date.value_tdt:{2018-03-18T04:00:00Z TO *]))]
```